### PR TITLE
Добавлена поддержка хедеров auth proxy

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -22,6 +22,7 @@ func main() {
 		internal.LogrusModule,
 
 		internal.JwtModule,
+		internal.AuthHeadersModule,
 		internal.AuthModule,
 		internal.ProxyModule,
 

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,15 +6,14 @@ auth:
   icon: https://is3-ssl.mzstatic.com/image/thumb/Purple118/v4/c1/3d/a5/c13da51a-5152-29d3-b668-4547e8873cc6/mzl.nhnzrmvu.png/230x0w.jpg
   cookie_name: auth_token # must match the name of the backend-auth cookie
   oauth_url: https://auth.wachanga.com/api/1.0/oauth/github
-  auth_headers:
-    include: true
-    headers:
-      # available properties: login, email
-      - header_name: "X-WACHANGA-WEBAUTH-USER"
-        header_property: "login"
-      - header_name: "X-WACHANGA-WEBAUTH-EMAIL"
-        header_property: "email"
   
+auth_headers:
+  enabled: true
+  headers:
+    # property: header_name
+    login: "X-WACHANGA-WEBAUTH-USER"
+    email: "X-WACHANGA-WEBAUTH-EMAIL"
+
 proxy:
   target: http://hello-world:80
   host: hello-world

--- a/config/config.yml
+++ b/config/config.yml
@@ -5,7 +5,7 @@ auth:
   title: some_service
   icon: https://is3-ssl.mzstatic.com/image/thumb/Purple118/v4/c1/3d/a5/c13da51a-5152-29d3-b668-4547e8873cc6/mzl.nhnzrmvu.png/230x0w.jpg
   cookie_name: auth_token # must match the name of the backend-auth cookie
-  oauth_url: http://auth.wachanga.com/oauth/github
+  oauth_url: https://auth.wachanga.com/api/1.0/oauth/github
   auth_headers:
     include: true
     headers:

--- a/config/config.yml
+++ b/config/config.yml
@@ -6,6 +6,14 @@ auth:
   icon: https://is3-ssl.mzstatic.com/image/thumb/Purple118/v4/c1/3d/a5/c13da51a-5152-29d3-b668-4547e8873cc6/mzl.nhnzrmvu.png/230x0w.jpg
   cookie_name: auth_token # must match the name of the backend-auth cookie
   oauth_url: http://auth.wachanga.com/oauth/github
+  auth_headers:
+    include: true
+    headers:
+      # available properties: login, email
+      - header_name: "X-WACHANGA-WEBAUTH-USER"
+        header_property: "login"
+      - header_name: "X-WACHANGA-WEBAUTH-EMAIL"
+        header_property: "email"
   
 proxy:
   target: http://hello-world:80

--- a/internal/auth_headers.go
+++ b/internal/auth_headers.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	"github.com/goava/di"
+	authheaders "github.com/pridemon/outpost/pkg/auth_headers"
+	"github.com/spf13/viper"
+)
+
+var AuthHeadersModule = di.Options(
+	di.Provide(AuthHeadersConfigProvider),
+)
+
+func AuthHeadersConfigProvider(v *viper.Viper) (*authheaders.AuthHeadersConfig, error) {
+	var config authheaders.AuthHeadersConfig
+	err := v.UnmarshalKey("auth_headers", &config)
+	return &config, err
+}

--- a/pkg/auth_headers/auth_headers.go
+++ b/pkg/auth_headers/auth_headers.go
@@ -1,0 +1,38 @@
+package authheaders
+
+import (
+	"net/http"
+
+	"github.com/goava/di"
+	"github.com/pridemon/outpost/pkg/jwt"
+	"github.com/sirupsen/logrus"
+)
+
+type AuthHeadersConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled" mapstructure:"enabled"`
+	// key - property, value - headerName
+	Headers map[string]string `json:"headers" yaml:"headers" mapstructure:"headers"`
+}
+
+type AuthHeadersService struct {
+	di.Inject
+
+	Log    *logrus.Logger
+	Config *AuthHeadersConfig
+}
+
+func (s *AuthHeadersService) Process(r *http.Request, claims *jwt.JwtClaims) {
+	if !s.Config.Enabled {
+		return
+	}
+
+	values := map[string]string{
+		"login": claims.Login,
+		"email": claims.Email,
+	}
+
+	for property, headerName := range s.Config.Headers {
+		r.Header.Set(headerName, values[property])
+		s.Log.WithField("header", headerName).Debug("header is set")
+	}
+}

--- a/pkg/jwt/jwt_service.go
+++ b/pkg/jwt/jwt_service.go
@@ -32,7 +32,7 @@ type JwtService struct {
 	Config *JwtConfig
 }
 
-func (s *JwtService) CheckAccessToken(accessToken string) bool {
+func (s *JwtService) CheckAccessToken(accessToken string) (bool, *JwtClaims) {
 	var claims JwtClaims
 	token, err := jwt.ParseWithClaims(accessToken, &claims, func(token *jwt.Token) (interface{}, error) {
 		return []byte(s.Config.SignKey), nil
@@ -41,8 +41,8 @@ func (s *JwtService) CheckAccessToken(accessToken string) bool {
 	if err != nil || !token.Valid ||
 		claims.Issuer != s.Config.Issuer || claims.Audience != s.Config.Audience {
 		s.Log.WithField("error", ErrBadAccessToken)
-		return false
+		return false, nil
 	}
 
-	return true
+	return true, &claims
 }


### PR DESCRIPTION
## Ссылки на связанные задачи/пулл реквесты
Ref: #5

## Статус PR 
READY

## Описание
- Добавлена отправка указанных в конфиге хедеров
- В конфиг добавлены
  -  опция `auth_headers.include` для включения отправки хедеров 
  - список хедеров (`auth_headers.headers`) с указанием названия хедера (`header_name`) и имени поля из jwt-токена, значение которого нужно записать в этот хедер (`header_property`)